### PR TITLE
Refactor template parameter handling

### DIFF
--- a/compiler/src/dmd/templateparamsem.d
+++ b/compiler/src/dmd/templateparamsem.d
@@ -60,7 +60,7 @@ private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
     override void visit(TemplateTypeParameter ttp)
     {
         //printf("TemplateTypeParameter.semantic('%s')\n", ident.toChars());
-        if (ttp.specType && !reliesOnTident(ttp.specType, parameters))
+        if (ttp.specType && !reliesOnTident(ttp.specType, *parameters))
         {
             ttp.specType = ttp.specType.typeSemantic(ttp.loc, sc);
         }
@@ -120,7 +120,7 @@ private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
 
     override void visit(TemplateAliasParameter tap)
     {
-        if (tap.specType && !reliesOnTident(tap.specType, parameters))
+        if (tap.specType && !reliesOnTident(tap.specType, *parameters))
         {
             tap.specType = tap.specType.typeSemantic(tap.loc, sc);
         }
@@ -165,7 +165,7 @@ RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplatePara
         return ea.ctfeInterpret();
     }
     Type ta = isType(o);
-    if (ta && (!parameters || !reliesOnTident(ta, parameters)))
+    if (ta && (!parameters || !reliesOnTident(ta, *parameters)))
     {
         Dsymbol s = ta.toDsymbol(sc);
         if (s)

--- a/compiler/src/dmd/templatesem.d
+++ b/compiler/src/dmd/templatesem.d
@@ -167,13 +167,13 @@ void templateDeclarationSemantic(Scope* sc, TemplateDeclaration tempdecl)
 
             if (TemplateTypeParameter ttp = (*tempdecl.parameters)[j].isTemplateTypeParameter())
             {
-                if (reliesOnTident(ttp.specType, &tparams))
+                if (reliesOnTident(ttp.specType, tparams))
                     tp.dependent = true;
             }
             else if (TemplateAliasParameter tap = (*tempdecl.parameters)[j].isTemplateAliasParameter())
             {
-                if (reliesOnTident(tap.specType, &tparams) ||
-                    reliesOnTident(isType(tap.specAlias), &tparams))
+                if (reliesOnTident(tap.specType, tparams) ||
+                    reliesOnTident(isType(tap.specAlias), tparams))
                 {
                     tp.dependent = true;
                 }
@@ -1292,7 +1292,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                 }
                 else if ((fparam.storageClass & STC.out_) == 0 &&
                          (argtype.ty == Tarray || argtype.ty == Tpointer) &&
-                         templateParameterLookup(prmtype, td.parameters) != IDX_NOTFOUND &&
+                         templateParameterLookup(prmtype, *td.parameters) != IDX_NOTFOUND &&
                          prmtype.isTypeIdentifier().idents.length == 0)
                 {
                     /* The farg passing to the prmtype always make a copy. Therefore,
@@ -1420,7 +1420,7 @@ extern (D) MATCHpair deduceFunctionTemplateMatch(TemplateDeclaration td, Templat
                     {
                         Expression dim = new IntegerExp(instLoc, fargs.length - argi, Type.tsize_t);
 
-                        size_t i = templateParameterLookup(taa.index, td.parameters);
+                        size_t i = templateParameterLookup(taa.index, *td.parameters);
                         if (i == IDX_NOTFOUND)
                         {
                             Expression e;


### PR DESCRIPTION
## Summary
- store TemplateParameters by value in `DeduceType`
- drop pointer dereferences and stale assertions
- adjust helper signatures and call sites
