### PR TITLE
Fix semanticLoc array access

### DIFF
--- a/compiler/src/dmd/dtemplate.d
+++ b/compiler/src/dmd/dtemplate.d
@@ -1317,7 +1317,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, ref TemplateParameters pa
     {
         Loc loc;
         if (parameters.length)
-            loc = (*parameters)[0].loc;
+            loc = parameters[0].loc;
         return loc;
     }
     extern (C++) final class DeduceType : Visitor


### PR DESCRIPTION
## Summary
- remove stale dereference of `TemplateParameters` in `semanticLoc`