### PR TITLE
Add Import.fullName and improve unused import warning

### DIFF
--- a/compiler/src/dmd/dimport.d
+++ b/compiler/src/dmd/dimport.d
@@ -164,6 +164,23 @@ extern (C++) final class Import : Dsymbol
         return imp && !imp.aliasId;
     }
 
+    /++
+     * Returns the fully qualified name of this import.
+     */
+    const(char)* fullName() const
+    {
+        import dmd.common.outbuffer : OutBuffer;
+
+        auto buf = OutBuffer();
+        foreach (pid; packages)
+        {
+            buf.writestring(pid.toString());
+            buf.writeByte('.');
+        }
+        buf.writestring(id.toString());
+        return buf.extractSlice(true).ptr;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1849,6 +1849,6 @@ private void checkUnusedImports(Module mod)
             }
         }
         if (!used)
-            global.errorSink.warning(imp.loc, "import `%s` is unused", imp.toChars());
+            global.errorSink.warning(imp.loc, "import `%s` is unused", imp.fullName());
     });
 }

--- a/compiler/test/unit/semantic/imports.d
+++ b/compiler/test/unit/semantic/imports.d
@@ -62,3 +62,26 @@ unittest
     assert(imports.any!(a => a == tuple("std.file", Visibility.Kind.private_)));
     assert(!imports.any!`a[0] == "std.algorithm"`); // not imported
 }
+
+@("unused selective import warning shows full module path")
+unittest
+{
+    import dmd.globals : global, DiagnosticReporting;
+
+    global.params.useWarnings = DiagnosticReporting.inform;
+
+    enum filename = "test.d";
+    enum code = q{
+        module test;
+        import std.algorithm.searching : countUntil;
+    }.stripDelimited;
+
+    const diagnostics = compiles(code, filename);
+
+    enum message = "Warning: import std.algorithm.searching is unused";
+    const expected = Diagnostic(SourceLoc(filename, 2, 1), message);
+
+    assert(diagnostics == [expected], "\n" ~ diagnostics.toString);
+
+    global.params.useWarnings = DiagnosticReporting.off;
+}


### PR DESCRIPTION
## Summary
- add `Import.fullName` helper to get fully qualified import name
- show full module path in `checkUnusedImports`
- test unused selective import warning with module path
