### PR TITLE
Improve unused import warnings

### DIFF
--- a/compiler/src/dmd/semantic3.d
+++ b/compiler/src/dmd/semantic3.d
@@ -1839,16 +1839,10 @@ private void checkUnusedImports(Module mod)
         if (!imp.aliasdecls.length)
             return; // only check selective imports
 
-        bool used = false;
         foreach (ad; imp.aliasdecls)
         {
-            if (ad.wasRead)
-            {
-                used = true;
-                break;
-            }
+            if (!ad.wasRead)
+                global.errorSink.warning(ad.loc, "import `%s` is unused", ad.toChars());
         }
-        if (!used)
-            global.errorSink.warning(imp.loc, "import `%s` is unused", imp.toChars());
     });
 }


### PR DESCRIPTION
## Summary
- check each selective import alias individually

## Testing
- `make unittest` *(fails: Couldn't find a D host compiler)*
- `pre-commit run --files compiler/src/dmd/semantic3.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887827c52708330a794281f3b690893