### PR TITLE
Refactor visibility lookup in hasPackageAccess

### DIFF
--- a/compiler/src/dmd/access.d
+++ b/compiler/src/dmd/access.d
@@ -67,14 +67,13 @@ private bool hasPackageAccess(Scope* sc, Dsymbol s)
 
 private bool hasPackageAccess(Module mod, Dsymbol s)
 {
+    const vis = s.visible();
     static if (LOG)
     {
-        printf("hasPackageAccess(s = '%s', mod = '%s', s.visibility.pkg = '%s')\n", s.toChars(), mod.toChars(), s.visible().pkg ? s.visible().pkg.toChars() : "NULL");
+        printf("hasPackageAccess(s = '%s', mod = '%s', s.visibility.pkg = '%s')\n", s.toChars(), mod.toChars(), vis.pkg ? vis.pkg.toChars() : "NULL");
     }
-    Package pkg = null;
-    if (s.visible().pkg)
-        pkg = s.visible().pkg;
-    else
+    Package pkg = vis.pkg;
+    if (!pkg)
     {
         // no explicit package for visibility, inferring most qualified one
         for (; s; s = s.parent)


### PR DESCRIPTION
## Summary
- avoid repeated `s.visible()` call by caching the result in `hasPackageAccess`

## Testing
- `make -j2 test` *(fails: Couldn't find a D host compiler)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f4bcb3de48330b318611295fa1ec3