### PR TITLE
Improve @nogc inference diagnostic messages

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -3221,7 +3221,9 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
 
     if (s.action.length > 0)
     {
-        errorFunc(s.loc, "and %.*s makes it fail to infer `%.*s`", s.action.fTuple.expand, attr.fTuple.expand);
+        errorFunc(s.loc,
+            "contaminated by `%.*s`, so `%s` cannot infer `%.*s`",
+            s.action.fTuple.expand, fd.toErrMsg(), attr.fTuple.expand);
         // For scope violations, also print why the target parameter is not scope
         if (s.scopeVar)
         {
@@ -3233,7 +3235,9 @@ public void errorSupplementalInferredAttr(FuncDeclaration fd, int maxDepth, bool
     {
         if (maxDepth > 0)
         {
-            errorFunc(s.loc, "which calls `%s`", s.fd.toErrMsg());
+            errorFunc(s.loc,
+                "`%s` cannot use `%.*s` because it calls `%s`",
+                fd.toErrMsg(), attr.fTuple.expand, s.fd.toErrMsg());
             errorSupplementalInferredAttr(s.fd, maxDepth - 1, deprecation, stc, eSink);
         }
     }

--- a/compiler/src/dmd/nogc.d
+++ b/compiler/src/dmd/nogc.d
@@ -362,7 +362,8 @@ extern (D) bool setGC(Scope* sc, FuncDeclaration fd, Loc loc, const(char)* fmt, 
             // Message wil be gagged, but still call error() to update global.errors and for
             // -verrors=spec
             string action = AttributeViolation(loc, fmt, args).action;
-            .error(loc, "%.*s is not allowed in a `@nogc` function", action.fTuple.expand);
+            .error(loc, "%.*s is not allowed in `@nogc` %s `%s`; this operation contaminates `@nogc` inference",
+                action.fTuple.expand, sc.func.kind(), sc.func.toErrMsg());
             return true;
         }
         return false;


### PR DESCRIPTION
### Motivation

- Make `@nogc` inference diagnostics more developer-friendly by clearly indicating what action contaminated inference and which function can no longer infer/use the attribute.

### Description

- Clarified supplemental inferred-attribute messaging in `errorSupplementalInferredAttr` to state that a function was "contaminated" by a specific action and to identify the function that cannot infer the attribute, changing phrasing for clarity in `compiler/src/dmd/expressionsem.d`.
- Improved the `__traits(compiles, ...)`-gagged `@nogc` error path in `setGC` to include the current function identity and explicitly state that the operation "contaminates `@nogc` inference" in `compiler/src/dmd/nogc.d`.
- Changes only modify diagnostic text and do not alter inference logic.

### Testing

- Ran `git diff --check` to verify there are no trailing whitespace or diff errors, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ddf23a1c83308d3501bbc35ab926)